### PR TITLE
fix(runtime): failure gating, join fixes, and test engine contract up…

### DIFF
--- a/docs/ai_runtime_workflow_guide.md
+++ b/docs/ai_runtime_workflow_guide.md
@@ -98,6 +98,9 @@ return RunSuccess(
 - Use `RunSuspended(...)` when a client or human must resume the run later.
 - Do not raise exceptions for expected business outcomes if you want workflow-level control over the result.
 - Raised exceptions are treated as resolver/runtime failures and typically become `RunFailure`.
+- If a `RunFailure` is matched by normal routing policy, the workflow can continue through the selected recovery branch.
+- If a `RunFailure` is not matched by routing policy, the run becomes failed and the runtime stops scheduling any new work from that point.
+- Steps that were already running may still finish and apply their state updates, but queued continuations and parked join releases are not scheduled after an unmatched failure.
 
 ## Minimal Example
 

--- a/kogwistar/docs/ARD-p2d-appendix-a-state-retries-ordering.md
+++ b/kogwistar/docs/ARD-p2d-appendix-a-state-retries-ordering.md
@@ -219,9 +219,12 @@ If a failure result produces a matching route:
 - continue through the selected recovery / retry / help branch
 
 If a failure result produces no route:
-- terminate the run with `status="failure"`
+- mark the run failed
+- stop scheduling any new downstream work
+- allow already-running work to drain and apply its state updates
+- do not release parked join waiters or queued continuations after that failure
 
-So `RunFailure` is neither “always hard-stop” nor “always recoverable”. The graph decides, and unmatched failure ends failed.
+So `RunFailure` is neither “always hard-stop” nor “always recoverable”. The graph decides, and unmatched failure ends failed after in-flight work drains, without spawning any new work.
 
 ### A7.5 Resume semantics for recoverable errors
 `resume_run(...)` must accept all structured result types from the external fixer:

--- a/kogwistar/runtime/runtime.py
+++ b/kogwistar/runtime/runtime.py
@@ -1192,7 +1192,7 @@ class WorkflowRuntime:
             _join_outstanding: list[int] = [
                 0 for _ in join_node_ids
             ]  # tokens BEFORE each join
-            _join_waiters: dict[str, list[int]] = {
+            _join_waiters: dict[str, list[tuple[int, str, str | None]]] = {
                 jid: [] for jid in join_node_ids
             }  # store per-token mask at join
 
@@ -1216,6 +1216,21 @@ class WorkflowRuntime:
             def _bit_for_join(join_id: str) -> int:
                 bi = _join_pos.get(join_id)
                 return (1 << bi) if bi is not None else 0
+
+            def _normalize_join_waiter(
+                item: Any,
+            ) -> tuple[int, str, str | None] | None:
+                if not isinstance(item, (list, tuple)):
+                    return None
+                if len(item) >= 3:
+                    return (
+                        int(item[0]),
+                        str(item[1]),
+                        (str(item[2]) if item[2] is not None else None),
+                    )
+                if len(item) == 1:
+                    return (int(item[0]), uuid.uuid4().hex, None)
+                return None
 
             def _rt_join_get() -> dict:
                 return cast(dict, state.get("_rt_join", {}))
@@ -1256,7 +1271,19 @@ class WorkflowRuntime:
                     "join_node_ids": join_node_ids,
                     "join_outstanding": list(_join_outstanding),
                     "join_waiters": {
-                        jid: list(masks) for jid, masks in _join_waiters.items()
+                        jid: [
+                            (
+                                int(mask),
+                                str(token_id),
+                                (
+                                    str(parent_token_id)
+                                    if parent_token_id is not None
+                                    else None
+                                ),
+                            )
+                            for mask, token_id, parent_token_id in waiters
+                        ]
+                        for jid, waiters in _join_waiters.items()
                     },
                     "pending": [
                         (
@@ -1309,9 +1336,14 @@ class WorkflowRuntime:
                     except Exception:
                         _join_outstanding[i] = 0
                 for jid in join_node_ids:
-                    masks = jw.get(jid, [])
-                    if isinstance(masks, list):
-                        _join_waiters[jid] = [int(x) for x in masks]
+                    items = jw.get(jid, [])
+                    if isinstance(items, list):
+                        normalized: list[tuple[int, str, str | None]] = []
+                        for item in items:
+                            norm = _normalize_join_waiter(item)
+                            if norm is not None:
+                                normalized.append(norm)
+                        _join_waiters[jid] = normalized
                 # pending tokens only; suspended tokens are restored by resume_run
                 out: list[tuple[str, int, str, str | None]] = []
                 for item in pend:
@@ -1380,6 +1412,31 @@ class WorkflowRuntime:
                 combined = sorted(pending_tokens.union(inflight_tokens))
                 suspended = sorted(suspended_tokens.values())
                 _rt_join_set(_rt_join_snapshot(combined, suspended=suspended))
+
+            def _enter_failed() -> bool:
+                nonlocal run_failed
+                if run_failed:
+                    return False
+                run_failed = True
+
+                while True:
+                    try:
+                        nid, mask, tok, parent_tok = scheduled_q.get_nowait()
+                    except queue.Empty:
+                        break
+                    pending_tokens.discard((str(nid), int(mask), str(tok), parent_tok))
+                    _dec(int(mask))
+
+                for jid in join_node_ids:
+                    waiters = list(_join_waiters.get(jid, []))
+                    if not waiters:
+                        continue
+                    _join_waiters[jid] = []
+                    for wm, _tok, _parent in waiters:
+                        _dec(int(wm))
+
+                _persist_rt_join_runtime()
+                return True
 
             def _cancel_requested() -> bool:
                 nonlocal cancel_info
@@ -1588,23 +1645,23 @@ class WorkflowRuntime:
                         except queue.Full as _e:
                             raise
                         t1 = _now_ms()
-                        if type(res) is not RunFailure:
-                            # step attempt complete (best-effort; never break worker)
-                            try:
-                                if ctx is None:
-                                    raise ValueError("ctx is None")
-                                self.emitter.step_completed(
-                                    ctx.trace_ctx,
-                                    status=str(status),
-                                    duration_ms=max(0, t1 - t0),
-                                )
-                            except Exception:
-                                status = "status_report_error"
-                            if status in ["error", "status_report_error"]:
-                                err_message = f"error on {node_id}, {res}"
-                                # to do, emit fail, then raise
-                                if getattr(wn, "fail_actiion", "raise") == "raise":
-                                    raise Exception(err_message)
+
+                        # step attempt complete (best-effort; never break worker)
+                        try:
+                            if ctx is None:
+                                raise ValueError('ctx is None')
+                            self.emitter.step_completed(
+                                ctx.trace_ctx,
+                                status=str(status),
+                                duration_ms=max(0, t1 - t0),
+                            )
+                        except Exception:
+                            status = "status_report_error"
+                        if status in ["error", "status_report_error"]:
+                            err_message = f"error on {node_id}, {res}"
+                            # to do, emit fail, then raise
+                            if getattr(wn, "fail_actiion", "raise") == "raise":
+                                raise Exception(err_message)
 
                         done_q.put(
                             (
@@ -1803,6 +1860,7 @@ class WorkflowRuntime:
 
                         # If this is a join/barrier node, it doesn't execute immediately.
                         if nid in _join_waiters:
+                            join_idx = _join_pos.get(nid)
                             join_bit = _bit_for_join(nid)
                             was_before_join = bool(mask & join_bit)
                             if was_before_join:
@@ -1839,8 +1897,7 @@ class WorkflowRuntime:
                             except Exception:
                                 pass
 
-                            _join_waiters[nid].append(mask)
-                            _persist_rt_join_runtime()
+                            _join_waiters[nid].append((mask, token_id, parent_token_id))
                             # trace: token waiting at join
                             try:
                                 join_idx = _join_pos.get(nid)
@@ -1871,60 +1928,47 @@ class WorkflowRuntime:
                             except Exception:
                                 pass
 
-                            # Release join when no more tokens are outstanding BEFORE it.
-                            # We merge all waiting tokens into ONE continuation token.
-                            join_idx = _join_pos.get(nid)
                             if _join_is_merge[nid]:
-                                if (
-                                    join_idx is not None
-                                    and _join_outstanding[join_idx] == 0
-                                ):
-                                    # trace: join released (all outstanding tokens before join have arrived)
-                                    try:
-                                        tcj = TraceContext(
-                                            run_id=str(run_id),
-                                            token_id=str(token_id),
-                                            step_seq=int(step_seq),
-                                            node_id=str(nid),
-                                            attempt=1,
-                                            conversation_id=str(conversation_id)
-                                            if conversation_id is not None
-                                            else None,
-                                            turn_node_id=str(turn_node_id)
-                                            if turn_node_id is not None
-                                            else None,
-                                        )
-                                        self.emitter.join_event(
-                                            tcj,
-                                            join_node_id=str(nid),
-                                            kind="released",
-                                            outstanding=0,
-                                        )
-                                    except Exception:
-                                        pass
-
-                                    wait_masks = _join_waiters[nid]
-                                    _join_waiters[nid] = []
-
-                                    # remove all waiter contributions (they will be merged)
-                                    for wm in wait_masks:
-                                        _dec(wm)
-
-                                    merged_mask = 0
-                                    if wait_masks:
-                                        merged_mask = wait_masks[0]
-                                        for wm in wait_masks[1:]:
-                                            merged_mask &= wm
-
-                                    # add merged token contribution
-                                    _inc(merged_mask)
-
-                                    # join can have an op, need to run through normal node ops.
+                                if join_idx is None or _join_outstanding[join_idx] != 0:
                                     _persist_rt_join_runtime()
-
-                                else:
-                                    # merge into 1, if not dec to 0, not the last to join, just continue
                                     continue
+                                waiters = list(_join_waiters.get(nid, []))
+                                if not waiters:
+                                    _persist_rt_join_runtime()
+                                    continue
+                                try:
+                                    tcj = TraceContext(
+                                        run_id=str(run_id),
+                                        token_id=str(waiters[0][1]),
+                                        step_seq=int(step_seq),
+                                        node_id=str(nid),
+                                        attempt=1,
+                                        conversation_id=str(conversation_id)
+                                        if conversation_id is not None
+                                        else None,
+                                        turn_node_id=str(turn_node_id)
+                                        if turn_node_id is not None
+                                        else None,
+                                    )
+                                    self.emitter.join_event(
+                                        tcj,
+                                        join_node_id=str(nid),
+                                        kind="released",
+                                        outstanding=0,
+                                    )
+                                except Exception:
+                                    pass
+                                _join_waiters[nid] = []
+                                merged_mask = int(waiters[0][0])
+                                token_id = str(waiters[0][1])
+                                parent_token_id = waiters[0][2]
+                                for wm, _tok, _parent in waiters:
+                                    _dec(int(wm))
+                                for wm, _tok, _parent in waiters[1:]:
+                                    merged_mask &= int(wm)
+                                _inc(int(merged_mask))
+                                mask = int(merged_mask)
+                            _persist_rt_join_runtime()
 
                         inflight_tokens.add(
                             (str(nid), int(mask), str(token_id), parent_token_id)
@@ -2090,10 +2134,10 @@ class WorkflowRuntime:
                     # route
                     if wn.terminal or len(adj.get(node_id, [])) == 0:
                         # token ends here -> it will never reach any remaining joins
+                        if status == "failure":
+                            _enter_failed()
                         _dec(mask)
                         _persist_rt_join_runtime()
-                        if status == "failure":
-                            run_failed = True
                         _checkpoint_current_step()
                         _enter_cancelling(
                             reason_node_id=str(node_id), token_id=str(token_id)
@@ -2158,11 +2202,27 @@ class WorkflowRuntime:
                     except Exception:
                         pass
 
-                    if not next_nodes:
+                    if status == "failure":
+                        handled_failure = any(
+                            reason in {"predicate", "explicit"}
+                            for _edge_id, _to_node_id, reason in getattr(
+                                route_decision, "selected", []
+                            )
+                        )
+                        if not handled_failure:
+                            next_nodes = []
+
+                    if run_failed:
                         _dec(mask)
                         _persist_rt_join_runtime()
+                        _checkpoint_current_step()
+                        continue
+
+                    if not next_nodes:
                         if status == "failure":
-                            run_failed = True
+                            _enter_failed()
+                        _dec(mask)
+                        _persist_rt_join_runtime()
 
                         if (step_seq_current % self.checkpoint_every_n_steps) == 0:
                             with self._maybe_step_uow():

--- a/tests/runtime/test_workflow_suspend_resume.py
+++ b/tests/runtime/test_workflow_suspend_resume.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 import asyncio
+import threading
 
 import pytest
 pytestmark = pytest.mark.core
@@ -202,6 +203,169 @@ def _log_workflow_entity_event_debug(
             )
             + "\n"
         )
+
+
+def _build_branch_failure_join_workflow(
+    wf_engine: GraphKnowledgeEngine,
+    wf_id: str,
+    *,
+    route_on_failure: bool,
+) -> None:
+    _create_node(wf_engine, wf_id, "start", "start_op", start=True, fanout=True)
+    _create_node(wf_engine, wf_id, "fail", "fail_op")
+    _create_node(wf_engine, wf_id, "downstream", "downstream_op")
+    _create_node(wf_engine, wf_id, "b", "branch_b_op")
+    _create_node(wf_engine, wf_id, "join", "join_op", wf_join=True)
+    _create_node(wf_engine, wf_id, "end", "end_op", terminal=True)
+
+    _create_edge(wf_engine, wf_id, "start", "fail")
+    _create_edge(wf_engine, wf_id, "start", "b")
+    _create_edge(
+        wf_engine,
+        wf_id,
+        "fail",
+        "downstream",
+        label="recover_on_failure",
+        predicate="if_failure" if route_on_failure else "if_not_failure",
+        is_default=False,
+    )
+    _create_edge(wf_engine, wf_id, "downstream", "join")
+    _create_edge(wf_engine, wf_id, "b", "join")
+    _create_edge(wf_engine, wf_id, "join", "end")
+
+
+def _branch_failure_join_resolver():
+    class _IfFailure:
+        def __call__(self, e, state, result):
+            return getattr(result, "status", None) == "failure"
+
+    class _IfNotFailure:
+        def __call__(self, e, state, result):
+            return getattr(result, "status", None) != "failure"
+
+    resolver = MappingStepResolver()
+
+    @resolver.register("start_op")
+    def _start(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"started": True})]
+        )
+
+    @resolver.register("fail_op")
+    def _fail(ctx: StepContext):
+        return RunFailure(
+            conversation_node_id=None,
+            state_update=[("u", {"failed_once": True})],
+            errors=["boom"],
+        )
+
+    @resolver.register("downstream_op")
+    def _downstream(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None,
+            state_update=[("u", {"downstream_done": True})],
+        )
+
+    @resolver.register("branch_b_op")
+    def _branch_b(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None,
+            state_update=[("u", {"b_done": True})],
+        )
+
+    @resolver.register("join_op")
+    def _join(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None,
+            state_update=[("u", {"joined": True})],
+        )
+
+    @resolver.register("end_op")
+    def _end(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None,
+            state_update=[("u", {"ended": True})],
+        )
+
+    return resolver, _IfFailure(), _IfNotFailure()
+
+
+def _build_deep_failure_join_workflow(
+    wf_engine: GraphKnowledgeEngine, wf_id: str
+) -> None:
+    _create_node(wf_engine, wf_id, "start", "start_op", start=True, fanout=True)
+    _create_node(wf_engine, wf_id, "b", "branch_b_op")
+    _create_node(wf_engine, wf_id, "c", "branch_c_op", fanout=True)
+    _create_node(wf_engine, wf_id, "d", "branch_d_op")
+    _create_node(wf_engine, wf_id, "e", "branch_e_op")
+    _create_node(wf_engine, wf_id, "f", "fail_op")
+    _create_node(wf_engine, wf_id, "join", "join_op", wf_join=True)
+    _create_node(wf_engine, wf_id, "end", "end_op", terminal=True)
+
+    _create_edge(wf_engine, wf_id, "start", "b")
+    _create_edge(wf_engine, wf_id, "start", "c")
+    _create_edge(wf_engine, wf_id, "c", "d")
+    _create_edge(wf_engine, wf_id, "c", "e")
+    _create_edge(wf_engine, wf_id, "b", "join")
+    _create_edge(wf_engine, wf_id, "d", "join")
+    _create_edge(wf_engine, wf_id, "e", "f")
+    _create_edge(wf_engine, wf_id, "f", "end")
+
+
+def _deep_failure_join_resolver():
+    resolver = MappingStepResolver()
+
+    @resolver.register("start_op")
+    def _start(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"started": True})]
+        )
+
+    @resolver.register("branch_b_op")
+    def _branch_b(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"b_done": True})]
+        )
+
+    @resolver.register("branch_c_op")
+    def _branch_c(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"c_done": True})]
+        )
+
+    @resolver.register("branch_d_op")
+    def _branch_d(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"d_done": True})]
+        )
+
+    @resolver.register("branch_e_op")
+    def _branch_e(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"e_done": True})]
+        )
+
+    @resolver.register("fail_op")
+    def _fail(ctx: StepContext):
+        return RunFailure(
+            conversation_node_id=None,
+            state_update=[("u", {"failed_once": True})],
+            errors=["boom"],
+        )
+
+    @resolver.register("join_op")
+    def _join(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"joined": True})]
+        )
+
+    @resolver.register("end_op")
+    def _end(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"ended": True})]
+        )
+
+    return resolver
 
 
 def _make_engine(
@@ -1027,25 +1191,28 @@ def test_workflow_failure_does_not_route_to_terminal(tmp_path, backend_kind):
     assert res.final_state.get("ended") is None
 
 
-@pytest.mark.ci
-def test_workflow_failure_does_not_follow_plain_default_edge(tmp_path):
+@pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
+def test_workflow_failure_waits_for_inflight_branch_drain(tmp_path, backend_kind):
     wf_engine = _make_engine(
-        tmp_path / "wf_fail_default_edge",
-        graph_type="workflow",
-        backend_kind="fake",
+        tmp_path / "wf_fail_drain", graph_type="workflow", backend_kind=backend_kind
     )
     conv_engine = _make_engine(
-        tmp_path / "conv_fail_default_edge",
-        graph_type="conversation",
-        backend_kind="fake",
+        tmp_path / "conv_fail_drain", graph_type="conversation", backend_kind=backend_kind
     )
 
-    wf_id = "test_failure_default_edge_unmatched"
-    _create_node(wf_engine, wf_id, "n_start", "start_op", start=True)
-    _create_node(wf_engine, wf_id, "n_exec", "exec_op")
-    _create_node(wf_engine, wf_id, "n_end", "end_op", terminal=True)
-    _create_edge(wf_engine, wf_id, "n_start", "n_exec")
-    _create_edge(wf_engine, wf_id, "n_exec", "n_end", is_default=True)
+    wf_id = "test_failure_waits_for_drain"
+    _create_node(wf_engine, wf_id, "start", "start_op", start=True, fanout=True)
+    _create_node(wf_engine, wf_id, "fail", "fail_op")
+    _create_node(wf_engine, wf_id, "slow", "slow_op")
+    _create_node(wf_engine, wf_id, "end", "end_op", terminal=True)
+    _create_edge(wf_engine, wf_id, "start", "fail")
+    _create_edge(wf_engine, wf_id, "start", "slow")
+    _create_edge(wf_engine, wf_id, "slow", "end")
+
+    slow_started = threading.Event()
+    release_slow = threading.Event()
+    failure_seen = threading.Event()
+    result_box: dict[str, RunSuccess | RunFailure | None] = {"res": None}
 
     resolver = MappingStepResolver()
 
@@ -1055,12 +1222,22 @@ def test_workflow_failure_does_not_follow_plain_default_edge(tmp_path):
             conversation_node_id=None, state_update=[("u", {"started": True})]
         )
 
-    @resolver.register("exec_op")
-    def _exec(ctx: StepContext):
+    @resolver.register("fail_op")
+    def _fail(ctx: StepContext):
+        failure_seen.set()
         return RunFailure(
             conversation_node_id=None,
             state_update=[("u", {"failed_once": True})],
             errors=["boom"],
+        )
+
+    @resolver.register("slow_op")
+    def _slow(ctx: StepContext):
+        slow_started.set()
+        if not release_slow.wait(timeout=10.0):
+            raise AssertionError("slow branch was not released")
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"slow_done": True})]
         )
 
     @resolver.register("end_op")
@@ -1068,6 +1245,176 @@ def test_workflow_failure_does_not_follow_plain_default_edge(tmp_path):
         return RunSuccess(
             conversation_node_id=None, state_update=[("u", {"ended": True})]
         )
+
+    runtime = WorkflowRuntime(
+        workflow_engine=wf_engine,
+        conversation_engine=conv_engine,
+        step_resolver=resolver,
+        predicate_registry={},
+        checkpoint_every_n_steps=1,
+        max_workers=4,
+    )
+
+    run_id = f"run_{uuid.uuid4().hex}"
+    conv_id = f"conv_{uuid.uuid4().hex}"
+
+    def _run() -> None:
+        result_box["res"] = runtime.run(
+            workflow_id=wf_id,
+            conversation_id=conv_id,
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=run_id,
+        )
+
+    t = threading.Thread(target=_run, name="workflow-failure-drain")
+    t.start()
+
+    assert slow_started.wait(10.0), "slow branch did not start"
+    assert failure_seen.wait(10.0), "failure branch did not run"
+    assert t.is_alive(), "run finished before the slow branch drained"
+
+    release_slow.set()
+    t.join(timeout=20.0)
+    assert not t.is_alive(), "run did not finish"
+
+    res = result_box["res"]
+    assert res is not None
+    assert res.status == "failure"
+    assert res.final_state.get("started") is True
+    assert res.final_state.get("failed_once") is True
+    assert res.final_state.get("slow_done") is True
+    assert res.final_state.get("ended") is None
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
+def test_workflow_failure_then_downstream_before_join_is_routed_when_handled(
+    tmp_path, backend_kind
+):
+    wf_engine = _make_engine(
+        tmp_path / "wf_fail_handled_join", graph_type="workflow", backend_kind=backend_kind
+    )
+    conv_engine = _make_engine(
+        tmp_path / "conv_fail_handled_join",
+        graph_type="conversation",
+        backend_kind=backend_kind,
+    )
+
+    wf_id = "test_failure_then_downstream_before_join_handled"
+    _build_branch_failure_join_workflow(wf_engine, wf_id, route_on_failure=True)
+    resolver, if_failure, _if_not_failure = _branch_failure_join_resolver()
+
+    runtime = WorkflowRuntime(
+        workflow_engine=wf_engine,
+        conversation_engine=conv_engine,
+        step_resolver=resolver,
+        predicate_registry={"if_failure": if_failure},
+        checkpoint_every_n_steps=1,
+    )
+
+    res = runtime.run(
+        workflow_id=wf_id,
+        conversation_id=f"conv_{uuid.uuid4().hex}",
+        turn_node_id="turn_1",
+        initial_state={
+            "conversation_id": "test",
+            "user_id": "test",
+            "turn_node_id": "test",
+            "turn_index": 0,
+            "role": "user",
+            "user_text": "",
+            "mem_id": "test",
+        },  # type: ignore
+        run_id=f"run_{uuid.uuid4().hex}",
+    )
+
+    assert res.status == "succeeded"
+    assert res.final_state.get("started") is True
+    assert res.final_state.get("failed_once") is True
+    assert res.final_state.get("downstream_done") is True
+    assert res.final_state.get("b_done") is True
+    assert res.final_state.get("joined") is True
+    assert res.final_state.get("ended") is True
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
+def test_workflow_failure_then_downstream_before_join_is_skipped_when_unhandled(
+    tmp_path, backend_kind
+):
+    wf_engine = _make_engine(
+        tmp_path / "wf_fail_unhandled_join",
+        graph_type="workflow",
+        backend_kind=backend_kind,
+    )
+    conv_engine = _make_engine(
+        tmp_path / "conv_fail_unhandled_join",
+        graph_type="conversation",
+        backend_kind=backend_kind,
+    )
+
+    wf_id = "test_failure_then_downstream_before_join_unhandled"
+    _build_branch_failure_join_workflow(wf_engine, wf_id, route_on_failure=False)
+    resolver, _if_failure, if_not_failure = _branch_failure_join_resolver()
+
+    runtime = WorkflowRuntime(
+        workflow_engine=wf_engine,
+        conversation_engine=conv_engine,
+        step_resolver=resolver,
+        predicate_registry={"if_not_failure": if_not_failure},
+        checkpoint_every_n_steps=1,
+    )
+
+    res = runtime.run(
+        workflow_id=wf_id,
+        conversation_id=f"conv_{uuid.uuid4().hex}",
+        turn_node_id="turn_1",
+        initial_state={
+            "conversation_id": "test",
+            "user_id": "test",
+            "turn_node_id": "test",
+            "turn_index": 0,
+            "role": "user",
+            "user_text": "",
+            "mem_id": "test",
+        },  # type: ignore
+        run_id=f"run_{uuid.uuid4().hex}",
+    )
+
+    assert res.status == "failure"
+    assert res.final_state.get("started") is True
+    assert res.final_state.get("failed_once") is True
+    assert res.final_state.get("downstream_done") is None
+    assert res.final_state.get("b_done") is True
+    assert res.final_state.get("joined") is None
+    assert res.final_state.get("ended") is None
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
+def test_workflow_failure_allows_existing_join_to_finish_but_blocks_downstream(
+    tmp_path, backend_kind
+):
+    wf_engine = _make_engine(
+        tmp_path / "wf_deep_failure_join",
+        graph_type="workflow",
+        backend_kind=backend_kind,
+    )
+    conv_engine = _make_engine(
+        tmp_path / "conv_deep_failure_join",
+        graph_type="conversation",
+        backend_kind=backend_kind,
+    )
+
+    wf_id = "test_deep_failure_join"
+    _build_deep_failure_join_workflow(wf_engine, wf_id)
+    resolver = _deep_failure_join_resolver()
 
     runtime = WorkflowRuntime(
         workflow_engine=wf_engine,
@@ -1095,7 +1442,12 @@ def test_workflow_failure_does_not_follow_plain_default_edge(tmp_path):
 
     assert res.status == "failure"
     assert res.final_state.get("started") is True
+    assert res.final_state.get("b_done") is True
+    assert res.final_state.get("c_done") is True
+    assert res.final_state.get("d_done") is True
+    assert res.final_state.get("e_done") is True
     assert res.final_state.get("failed_once") is True
+    assert res.final_state.get("joined") is True
     assert res.final_state.get("ended") is None
 
 
@@ -1174,6 +1526,363 @@ async def test_workflow_failure_does_not_route_to_terminal_async_backends(
         assert res.status == "failure"
         assert res.final_state.get("started") is True
         assert res.final_state.get("ended") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_workflow_failure_waits_for_inflight_branch_drain_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_failure_waits_for_drain_async"
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "start", "start_op", True, False, True
+        )
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "fail", "fail_op")
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "slow", "slow_op")
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "end", "end_op", False, True)
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "start", "fail")
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "start", "slow")
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "slow", "end")
+
+        slow_started = threading.Event()
+        release_slow = threading.Event()
+        failure_seen = threading.Event()
+        result_box: dict[str, Any] = {"res": None}
+
+        resolver = MappingStepResolver()
+
+        @resolver.register("start_op")
+        def _start(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"started": True})]
+            )
+
+        @resolver.register("fail_op")
+        def _fail(ctx: StepContext):
+            failure_seen.set()
+            return RunFailure(
+                conversation_node_id=None,
+                state_update=[("u", {"failed_once": True})],
+                errors=["boom"],
+            )
+
+        @resolver.register("slow_op")
+        def _slow(ctx: StepContext):
+            slow_started.set()
+            if not release_slow.wait(timeout=10.0):
+                raise AssertionError("slow branch was not released")
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"slow_done": True})]
+            )
+
+        @resolver.register("end_op")
+        def _end(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"ended": True})]
+            )
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={},
+            checkpoint_every_n_steps=1,
+            max_workers=4,
+        )
+
+        run_id = f"run_{uuid.uuid4().hex}"
+        conv_id = f"conv_{uuid.uuid4().hex}"
+
+        def _run() -> None:
+            result_box["res"] = runtime.run(
+                workflow_id=wf_id,
+                conversation_id=conv_id,
+                turn_node_id="turn_1",
+                initial_state={
+                    "conversation_id": "test",
+                    "user_id": "test",
+                    "turn_node_id": "test",
+                    "turn_index": 0,
+                    "role": "user",
+                    "user_text": "",
+                    "mem_id": "test",
+                },
+                run_id=run_id,
+            )
+
+        t = threading.Thread(target=_run, name="workflow-failure-drain-async")
+        t.start()
+
+        assert await asyncio.to_thread(slow_started.wait, 10.0), "slow branch did not start"
+        assert await asyncio.to_thread(failure_seen.wait, 10.0), "failure branch did not run"
+        assert t.is_alive(), "run finished before the slow branch drained"
+
+        release_slow.set()
+        await asyncio.to_thread(t.join, 20.0)
+        assert not t.is_alive(), "run did not finish"
+
+        res = result_box["res"]
+        assert res is not None
+        assert res.status == "failure"
+        assert res.final_state.get("started") is True
+        assert res.final_state.get("failed_once") is True
+        assert res.final_state.get("slow_done") is True
+        assert res.final_state.get("ended") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_workflow_failure_then_downstream_before_join_is_routed_when_handled_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_failure_then_downstream_before_join_handled_async"
+        await asyncio.to_thread(
+            _build_branch_failure_join_workflow,
+            wf_engine,
+            wf_id,
+            route_on_failure=True,
+        )
+        resolver, if_failure, _if_not_failure = _branch_failure_join_resolver()
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={"if_failure": if_failure},
+            checkpoint_every_n_steps=1,
+        )
+
+        res = await asyncio.to_thread(
+            runtime.run,
+            workflow_id=wf_id,
+            conversation_id=f"conv_{uuid.uuid4().hex}",
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=f"run_{uuid.uuid4().hex}",
+        )
+
+        assert res.status == "succeeded"
+        assert res.final_state.get("started") is True
+        assert res.final_state.get("failed_once") is True
+        assert res.final_state.get("downstream_done") is True
+        assert res.final_state.get("b_done") is True
+        assert res.final_state.get("joined") is True
+        assert res.final_state.get("ended") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_workflow_failure_then_downstream_before_join_is_skipped_when_unhandled_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_failure_then_downstream_before_join_unhandled_async"
+        await asyncio.to_thread(
+            _build_branch_failure_join_workflow,
+            wf_engine,
+            wf_id,
+            route_on_failure=False,
+        )
+        resolver, _if_failure, if_not_failure = _branch_failure_join_resolver()
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={"if_not_failure": if_not_failure},
+            checkpoint_every_n_steps=1,
+        )
+
+        res = await asyncio.to_thread(
+            runtime.run,
+            workflow_id=wf_id,
+            conversation_id=f"conv_{uuid.uuid4().hex}",
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=f"run_{uuid.uuid4().hex}",
+        )
+
+        assert res.status == "failure"
+        assert res.final_state.get("started") is True
+        assert res.final_state.get("failed_once") is True
+        assert res.final_state.get("downstream_done") is None
+        assert res.final_state.get("b_done") is True
+        assert res.final_state.get("joined") is None
+        assert res.final_state.get("ended") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_workflow_failure_allows_existing_join_to_finish_but_blocks_downstream_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_deep_failure_join_async"
+        await asyncio.to_thread(_build_deep_failure_join_workflow, wf_engine, wf_id)
+        resolver = _deep_failure_join_resolver()
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={},
+            checkpoint_every_n_steps=1,
+        )
+
+        res = await asyncio.to_thread(
+            runtime.run,
+            workflow_id=wf_id,
+            conversation_id=f"conv_{uuid.uuid4().hex}",
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=f"run_{uuid.uuid4().hex}",
+        )
+
+        assert res.status == "failure"
+        assert res.final_state.get("started") is True
+        assert res.final_state.get("b_done") is True
+        assert res.final_state.get("c_done") is True
+        assert res.final_state.get("d_done") is True
+        assert res.final_state.get("e_done") is True
+        assert res.final_state.get("failed_once") is True
+        assert res.final_state.get("joined") is True
+        assert res.final_state.get("ended") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_workflow_failure_can_route_to_recovery_branch_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_failure_routes_async"
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "start", "start_op", True, False
+        )
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "exec", "exec_op")
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "recover", "recover_op")
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "end", "end_op", False, True
+        )
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "start", "exec")
+        await asyncio.to_thread(
+            _create_edge,
+            wf_engine,
+            wf_id,
+            "exec",
+            "recover",
+            label="recover_on_failure",
+            predicate="if_failure",
+            is_default=False,
+        )
+        await asyncio.to_thread(
+            _create_edge, wf_engine, wf_id, "exec", "end", label="finish", is_default=True
+        )
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "recover", "end")
+
+        class _IfFailure:
+            def __call__(self, e, state, result):
+                return getattr(result, "status", None) == "failure"
+
+        resolver = MappingStepResolver()
+
+        @resolver.register("start_op")
+        def _start(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"started": True})]
+            )
+
+        @resolver.register("exec_op")
+        def _exec(ctx: StepContext):
+            return RunFailure(
+                conversation_node_id=None,
+                state_update=[("u", {"failed_once": True})],
+                errors=["boom"],
+            )
+
+        @resolver.register("recover_op")
+        def _recover(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"recovered": True})]
+            )
+
+        @resolver.register("end_op")
+        def _end(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"ended": True})]
+            )
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={"if_failure": _IfFailure()},
+            checkpoint_every_n_steps=1,
+        )
+
+        res = await asyncio.to_thread(
+            runtime.run,
+            workflow_id=wf_id,
+            conversation_id=f"conv_{uuid.uuid4().hex}",
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=f"run_{uuid.uuid4().hex}",
+        )
+
+        assert res.status == "succeeded"
+        assert res.final_state.get("started") is True
+        assert res.final_state.get("failed_once") is True
+        assert res.final_state.get("recovered") is True
+        assert res.final_state.get("ended") is True
 
 
 @pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
@@ -1374,6 +2083,128 @@ def test_resume_run_failure_can_route_to_recovery_branch(
     assert res2.final_state.get("resume_failed") is True
     assert res2.final_state.get("failure_routed") is True
     assert res2.final_state.get("ended") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_resume_run_failure_can_route_to_recovery_branch_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_resume_failure_routes_async"
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "start", "start_op", True, False
+        )
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "gate", "suspend_op")
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "recover", "recover_op")
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "end", "end_op", False, True)
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "start", "gate")
+        await asyncio.to_thread(
+            _create_edge,
+            wf_engine,
+            wf_id,
+            "gate",
+            "recover",
+            label="recover_on_failure",
+            predicate="if_failure",
+            is_default=False,
+        )
+        await asyncio.to_thread(
+            _create_edge, wf_engine, wf_id, "gate", "end", label="finish", is_default=True
+        )
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "recover", "end")
+
+        class _IfFailure:
+            def __call__(self, e, state, result):
+                return getattr(result, "status", None) == "failure"
+
+        resolver = MappingStepResolver()
+
+        @resolver.register("start_op")
+        def _start(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"started": True})]
+            )
+
+        @resolver.register("suspend_op")
+        def _suspend(ctx: StepContext):
+            return RunSuspended(
+                conversation_node_id=None,
+                state_update=[],
+                resume_payload={
+                    "type": "recoverable_error",
+                    "op": "suspend_op",
+                    "category": "missing_input",
+                    "message": "need fix",
+                    "errors": ["need fix"],
+                    "repair_payload": {"prompt": "fix it"},
+                },
+            )
+
+        @resolver.register("recover_op")
+        def _recover(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"failure_routed": True})]
+            )
+
+        @resolver.register("end_op")
+        def _end(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"ended": True})]
+            )
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={"if_failure": _IfFailure()},
+            checkpoint_every_n_steps=1,
+        )
+
+        run_id = f"run_{uuid.uuid4().hex}"
+        conv_id = f"conv_{uuid.uuid4().hex}"
+        res1 = await asyncio.to_thread(
+            runtime.run,
+            workflow_id=wf_id,
+            conversation_id=conv_id,
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=run_id,
+        )
+        state1 = await asyncio.to_thread(_latest_checkpoint_state, conv_engine, run_id)
+        suspended_token_id = state1["_rt_join"]["suspended"][0][2]
+
+        res2 = await asyncio.to_thread(
+            runtime.resume_run,
+            run_id=run_id,
+            suspended_node_id="gate",
+            suspended_token_id=suspended_token_id,
+            client_result=RunFailure(
+                conversation_node_id=None,
+                state_update=[("u", {"resume_failed": True})],
+                errors=["still broken"],
+            ),
+            workflow_id=wf_id,
+            conversation_id=conv_id,
+            turn_node_id="turn_1",
+        )
+
+        assert res1.status == "suspended"
+        assert res2.status == "succeeded"
+        assert res2.final_state.get("resume_failed") is True
+        assert res2.final_state.get("failure_routed") is True
+        assert res2.final_state.get("ended") is True
 
 
 @pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)

--- a/tests/runtime/test_workflow_suspend_resume.py
+++ b/tests/runtime/test_workflow_suspend_resume.py
@@ -1885,6 +1885,98 @@ async def test_workflow_failure_can_route_to_recovery_branch_async_backends(
         assert res.final_state.get("ended") is True
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend_kind", ASYNC_BACKEND_PARAMS)
+async def test_workflow_failure_does_not_take_default_recovery_edge_async_backends(
+    tmp_path, backend_kind, request
+):
+    async with _async_runtime_engine_pair(backend_kind, request, tmp_path) as (
+        wf_engine,
+        conv_engine,
+    ):
+        wf_id = "test_failure_default_recovery_async"
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "start", "start_op", True, False
+        )
+        await asyncio.to_thread(_create_node, wf_engine, wf_id, "exec", "exec_op")
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "recover", "recover_op"
+        )
+        await asyncio.to_thread(
+            _create_node, wf_engine, wf_id, "end", "end_op", False, True
+        )
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "start", "exec")
+        await asyncio.to_thread(
+            _create_edge,
+            wf_engine,
+            wf_id,
+            "exec",
+            "recover",
+            label="recover_by_default",
+            is_default=True,
+        )
+        await asyncio.to_thread(_create_edge, wf_engine, wf_id, "recover", "end")
+
+        resolver = MappingStepResolver()
+
+        @resolver.register("start_op")
+        def _start(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"started": True})]
+            )
+
+        @resolver.register("exec_op")
+        def _exec(ctx: StepContext):
+            return RunFailure(
+                conversation_node_id=None,
+                state_update=[("u", {"failed_once": True})],
+                errors=["boom"],
+            )
+
+        @resolver.register("recover_op")
+        def _recover(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"recovered": True})]
+            )
+
+        @resolver.register("end_op")
+        def _end(ctx: StepContext):
+            return RunSuccess(
+                conversation_node_id=None, state_update=[("u", {"ended": True})]
+            )
+
+        runtime = WorkflowRuntime(
+            workflow_engine=wf_engine,
+            conversation_engine=conv_engine,
+            step_resolver=resolver,
+            predicate_registry={},
+            checkpoint_every_n_steps=1,
+        )
+
+        res = await asyncio.to_thread(
+            runtime.run,
+            workflow_id=wf_id,
+            conversation_id=f"conv_{uuid.uuid4().hex}",
+            turn_node_id="turn_1",
+            initial_state={
+                "conversation_id": "test",
+                "user_id": "test",
+                "turn_node_id": "test",
+                "turn_index": 0,
+                "role": "user",
+                "user_text": "",
+                "mem_id": "test",
+            },
+            run_id=f"run_{uuid.uuid4().hex}",
+        )
+
+        assert res.status == "failure"
+        assert res.final_state.get("started") is True
+        assert res.final_state.get("failed_once") is True
+        assert res.final_state.get("recovered") is None
+        assert res.final_state.get("ended") is None
+
+
 @pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
 def test_workflow_failure_can_route_to_recovery_branch(
     tmp_path, backend_kind
@@ -1970,6 +2062,96 @@ def test_workflow_failure_can_route_to_recovery_branch(
     assert res.final_state.get("failed_once") is True
     assert res.final_state.get("recovered") is True
     assert res.final_state.get("ended") is True
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)
+def test_workflow_failure_does_not_take_default_recovery_edge(
+    tmp_path, backend_kind
+):
+    wf_engine = _make_engine(
+        tmp_path / "wf_fail_default_recovery",
+        graph_type="workflow",
+        backend_kind=backend_kind,
+    )
+    conv_engine = _make_engine(
+        tmp_path / "conv_fail_default_recovery",
+        graph_type="conversation",
+        backend_kind=backend_kind,
+    )
+
+    wf_id = "test_failure_default_recovery"
+    _create_node(wf_engine, wf_id, "start", "start_op", start=True)
+    _create_node(wf_engine, wf_id, "exec", "exec_op")
+    _create_node(wf_engine, wf_id, "recover", "recover_op")
+    _create_node(wf_engine, wf_id, "end", "end_op", terminal=True)
+    _create_edge(wf_engine, wf_id, "start", "exec")
+    _create_edge(
+        wf_engine,
+        wf_id,
+        "exec",
+        "recover",
+        label="recover_by_default",
+        is_default=True,
+    )
+    _create_edge(wf_engine, wf_id, "recover", "end")
+
+    resolver = MappingStepResolver()
+
+    @resolver.register("start_op")
+    def _start(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"started": True})]
+        )
+
+    @resolver.register("exec_op")
+    def _exec(ctx: StepContext):
+        return RunFailure(
+            conversation_node_id=None,
+            state_update=[("u", {"failed_once": True})],
+            errors=["boom"],
+        )
+
+    @resolver.register("recover_op")
+    def _recover(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"recovered": True})]
+        )
+
+    @resolver.register("end_op")
+    def _end(ctx: StepContext):
+        return RunSuccess(
+            conversation_node_id=None, state_update=[("u", {"ended": True})]
+        )
+
+    runtime = WorkflowRuntime(
+        workflow_engine=wf_engine,
+        conversation_engine=conv_engine,
+        step_resolver=resolver,
+        predicate_registry={},
+        checkpoint_every_n_steps=1,
+    )
+
+    res = runtime.run(
+        workflow_id=wf_id,
+        conversation_id=f"conv_{uuid.uuid4().hex}",
+        turn_node_id="turn_1",
+        initial_state={
+            "conversation_id": "test",
+            "user_id": "test",
+            "turn_node_id": "test",
+            "turn_index": 0,
+            "role": "user",
+            "user_text": "",
+            "mem_id": "test",
+        },  # type: ignore
+        run_id=f"run_{uuid.uuid4().hex}",
+    )
+
+    assert res.status == "failure"
+    assert res.final_state.get("started") is True
+    assert res.final_state.get("failed_once") is True
+    assert res.final_state.get("recovered") is None
+    assert res.final_state.get("ended") is None
 
 
 @pytest.mark.parametrize("backend_kind", BACKEND_PARAMS)

--- a/tests/workflow/test_workflow_join.py
+++ b/tests/workflow/test_workflow_join.py
@@ -45,6 +45,8 @@ class FakeConversationEngine:
     def __init__(self) -> None:
         self.nodes = []
         self.edges = []
+        self.read = self
+        self.write = self
 
     def add_node(self, n):
         self.nodes.append(n)
@@ -65,6 +67,8 @@ class FakeWorkflowEngine:
     def __init__(self, nodes: List[FakeNode], edges: List[FakeEdge]) -> None:
         self._nodes = nodes
         self._edges = edges
+        self.read = self
+        self.write = self
 
     def get_nodes(self, where=None, limit=5000, **kwarg):
         # ignore where in tests


### PR DESCRIPTION
This PR tightens runtime failure semantics and closes a few contract gaps exposed while testing:

Unhandled RunFailure now acts as a fail-fast gate for new scheduling, while still allowing already-running work to finish.
Join bookkeeping was updated so parked join continuations can be restored and resumed correctly without re-trigger loops.
Failure routing behavior is pinned so handled recovery predicates still work, but default/unconditional fallback does not accidentally rescue an unhandled failure.
Test doubles for workflow/conversation engines were brought up to the current read/write contract so join tests exercise runtime behavior instead of failing on stale harness shape.
Runtime and ARD/docs were updated to reflect the current semantics.
Validation:

tests/runtime/test_workflow_suspend_resume.py
tests/workflow/test_workflow_join.py